### PR TITLE
Show absolute amount of matching cards instead of percentage value

### DIFF
--- a/Advisor/Advisor.cs
+++ b/Advisor/Advisor.cs
@@ -264,7 +264,14 @@ namespace HDT.Plugins.Advisor
                     // Select best matched deck with both highest similarity value and most played games
                     var matchedDeck = topGamesDecks.First();
 
-                    _advisorOverlay.LblArchetype.Text = String.Format("{0} ({1}%)", matchedDeck.Key.Name, Math.Round(matchedDeck.Value * 100, 2));
+                    // Count how many cards from opponent deck are in selected deck
+                    int matchingCards = 0;
+                    foreach (var opponentDeckCard in opponentCardlist)
+                        foreach (var selectedDeckCard in matchedDeck.Key.Cards)
+                            if (!opponentDeckCard.IsCreated && opponentDeckCard.Equals(selectedDeckCard))
+                                matchingCards++;
+
+                    _advisorOverlay.LblArchetype.Text = String.Format("{0} ({1}/{2})", matchedDeck.Key.Name, matchingCards, opponentCardlist.Count);
                     _advisorOverlay.LblStats.Text = String.Format("{0}", matchedDeck.Key.Note);
                     Deck deck = DeckList.Instance.Decks.Where(d => d.TagList.ToLowerInvariant().Contains("archetype")).First(d => d.Name == matchedDeck.Key.Name);
                     if (deck != null)


### PR DESCRIPTION
This makes it easier to see how similar the opponent's deck is compared to the selected one.
It shows the amount of cards played from the deck (right number) and the amount of played cards that actually matched the deck chosen by Advisor (left number).

Before:
![2017-05-16 12_55_16-hearthstoneoverlay](https://cloud.githubusercontent.com/assets/225291/26102856/3887ea5a-3a37-11e7-9cd1-18615aca7cfb.png)

After:
![2017-05-16 12_52_38-hearthstoneoverlay](https://cloud.githubusercontent.com/assets/225291/26102869/423f7982-3a37-11e7-84d7-8ac5068da043.png)

I am not 100% sure that all cards are counted. I used the IsCreated function to ignore cards that have been added by e.g. spells, but maybe there is more left to check.